### PR TITLE
Allow U-lined servers to remove all network-wide bans in case of an emergency

### DIFF
--- a/include/msg.h
+++ b/include/msg.h
@@ -99,6 +99,7 @@
 #define MSG_SVSHOLD  "SVSHOLD"		/* SVSHOLD */
 #define MSG_AKILL    "AKILL"     	/* AKILL */
 #define MSG_RAKILL   "RAKILL"    	/* RAKILL */
+#define MSG_NBANRESET "NBANRESET" 	/* NBANRESET */
 #define MSG_SILENCE  "SILENCE"   	/* SILENCE */
 #define MSG_WATCH    "WATCH"     	/* WATCH */
 #define MSG_SQLINE   "SQLINE" 		/* SQLINE */
@@ -137,6 +138,7 @@ extern int  m_kline(aClient *, aClient *, int, char **);
 extern int  m_unkline(aClient *, aClient *, int, char **);
 extern int  m_akill(aClient *, aClient *, int, char **);
 extern int  m_rakill(aClient *, aClient *, int, char **);
+extern int  m_nbanreset(aClient *, aClient *, int, char **);
 extern int  m_locops(aClient *, aClient *, int, char **);
 extern int  m_private(aClient *, aClient *, int, char **);
 extern int  m_topic(aClient *, aClient *, int, char **);
@@ -329,6 +331,7 @@ struct Message msgtab[] =
     {MSG_SVSHOLD,  m_svshold,  MAXPARA, 0,        0},
     {MSG_AKILL,    m_akill,    MAXPARA, 0,        0},
     {MSG_RAKILL,   m_rakill,   MAXPARA, 0,        0},
+    {MSG_NBANRESET,m_nbanreset,      1, 0,        0},
     {MSG_SILENCE,  m_silence,  MAXPARA, 0,        0},
     {MSG_WATCH,    m_watch,          1, 0,        0},
     {MSG_DCCALLOW, m_dccallow,       1, 0,        0},

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -2604,6 +2604,38 @@ m_rakill(aClient *cptr, aClient *sptr, int parc, char *parv[])
     return 0;
 }
 
+/*
+ * Allow U-lined servers to remove all network-wide bans in case of an emergency -xPsycho
+ */
+
+int
+m_nbanreset(aClient *cptr, aClient *sptr, int parc, char *parv[])
+{
+    if(!IsServer(sptr))
+    {
+        return 0;
+    }
+
+    if(!IsULine(sptr))
+    {
+        sendto_serv_butone(&me, ":%s GLOBOPS :Non-ULined server %s trying to NBANRESET!",  me.name, sptr->name);
+        send_globops("From %s: Non-ULined server %s trying to NBANRESET!", me.name, sptr->name);
+        return 0;
+    }
+
+    sendto_ops("%s is removing all network bans and resetting throttles", sptr->name);
+
+    remove_userbans_match_flags(UBAN_NETWORK, 0);
+    remove_simbans_match_flags(SBAN_NICK|SBAN_NETWORK, 0);
+    remove_simbans_match_flags(SBAN_CHAN|SBAN_NETWORK, 0);
+    remove_simbans_match_flags(SBAN_GCOS|SBAN_NETWORK, 0);
+    throttle_rehash();
+
+    sendto_serv_butone(cptr, ":%s NBANRESET", sptr->name);
+
+    return 0;
+}
+
         
 /*
  * RPL_NOWON   - Online at the moment (Succesfully added to WATCH-list)


### PR DESCRIPTION
Allow U-lined servers to remove all network-wide bans in case of an emergency.

This will allow services to remove all AKILLS, SQLINES, and SGLINES and reset connection throttles in a rogue ban is set.