### PR TITLE
Allow admins to see who is using /whois on them if umode +y

### DIFF
--- a/src/s_user.c
+++ b/src/s_user.c
@@ -2099,7 +2099,16 @@ m_whois(aClient *cptr, aClient *sptr, int parc, char *parv[])
                 !IsUmodeI(acptr) || (parc > 2) || IsAnOper(sptr)))
             sendto_one(sptr, rpl_str(RPL_WHOISIDLE), me.name, parv[0], name,
                        timeofday - user->last, acptr->firsttime);
-        
+
+
+		if (sptr->user && IsAdmin(acptr) && SendSpyNotice(acptr))
+		{
+			sendto_one(acptr, ":%s NOTICE %s "
+				":*** Spy -- %s!%s@%s is doing a /whois on you.",
+				me.name, name,
+				sptr->name, sptr->user->username, sptr->user->host);
+		}
+
         continue;
     }
     sendto_one(sptr, rpl_str(RPL_ENDOFWHOIS), me.name, parv[0], parv[1]);


### PR DESCRIPTION
This is in sporadic use by some servers already, but not everyone has it so we might as well make it universal.